### PR TITLE
Add support for sections tag

### DIFF
--- a/liquid/tags.yml
+++ b/liquid/tags.yml
@@ -23,6 +23,7 @@
 - render
 - schema: endschema
 - section
+- sections
 - style: endstyle
 - stylesheet
 - tablerow

--- a/tests/baselines/tag-sections.baseline.txt
+++ b/tests/baselines/tag-sections.baseline.txt
@@ -1,0 +1,30 @@
+original file
+-----------------------------------
+{% sections 'header' %}
+
+-----------------------------------
+
+Grammar: liquid.tmLanguage.json
+-----------------------------------
+>{% sections 'header' %}
+ ^^
+ text.html.liquid meta.tag.liquid punctuation.definition.tag.begin.liquid
+   ^
+   text.html.liquid meta.tag.liquid meta.entity.tag.liquid
+    ^^^^^^^^
+    text.html.liquid meta.tag.liquid meta.entity.tag.liquid entity.name.tag.liquid
+            ^
+            text.html.liquid meta.tag.liquid meta.entity.tag.liquid
+             ^
+             text.html.liquid meta.tag.liquid meta.entity.tag.liquid string.quoted.single.liquid
+              ^^^^^^
+              text.html.liquid meta.tag.liquid meta.entity.tag.liquid string.quoted.single.liquid
+                    ^
+                    text.html.liquid meta.tag.liquid meta.entity.tag.liquid string.quoted.single.liquid
+                     ^
+                     text.html.liquid meta.tag.liquid meta.entity.tag.liquid
+                      ^^
+                      text.html.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+>
+ ^
+ text.html.liquid

--- a/tests/cases/tag-sections.liquid
+++ b/tests/cases/tag-sections.liquid
@@ -1,0 +1,1 @@
+{% sections 'header' %}


### PR DESCRIPTION
### WHY are these changes introduced?
As we are planning to introduce a new liquid tag to render section groups, we want to make sure [liquid-tm-grammar](https://github.com/Shopify/liquid-tm-grammar) is able to recognize and handle the new liquid tag.

The new sections tag is use as followed: 
`{% sections '<type>` %}`