### PR TITLE
Add liquid syntax for new doc_tag

### DIFF
--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -5,6 +5,7 @@ repository:
   core:
     patterns:
       - include: '#raw_tag'
+      - include: '#doc_tag'
       - include: '#comment_block'
       - include: '#style_codefence'
       - include: '#stylesheet_codefence'
@@ -32,6 +33,32 @@ repository:
     contentName: string.unquoted.liquid
     patterns:
       - match: '(.(?!{%-?\s*endraw\s*-?%}))*.'
+
+  doc_tag:
+    begin: '{%-?\s*(doc)\s*-?%}'
+    end: '{%-?\s*(enddoc)\s*-?%}'
+    name: meta.block.doc.liquid
+    contentName: comment.block.documentation.liquid
+    beginCaptures:
+      0: { name: meta.tag.liquid }
+      1: { name: entity.name.tag.doc.liquid }
+    endCaptures:
+      0: { name: meta.tag.liquid }
+      1: { name: entity.name.tag.doc.liquid }
+    patterns:
+      - include: '#doc_param'
+      - include: '#doc_at_sign'
+
+  doc_at_sign:
+    match: '@[a-zA-Z]+'
+    name: storage.type.class.liquid
+
+  doc_param:
+    match: '(@param)\s+(?:({[^}]*}?)\s+)?([a-zA-Z_]\w*)?'
+    captures:
+      1: { name: storage.type.class.liquid }
+      2: { name: entity.name.type.instance.liquid }
+      3: { name: variable.other.liquid }
 
   comment_block:
     begin: '{%-?\s*comment\s*-?%}'

--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -46,19 +46,26 @@ repository:
       0: { name: meta.tag.liquid }
       1: { name: entity.name.tag.doc.liquid }
     patterns:
-      - include: '#doc_param'
-      - include: '#doc_at_sign'
+      - include: '#liquid_doc_param_tag'
+      - include: '#liquid_doc_example_tag'
+      - include: '#liquid_doc_fallback_tag'
 
-  doc_at_sign:
-    match: '@[a-zA-Z]+'
-    name: storage.type.class.liquid
-
-  doc_param:
+  liquid_doc_param_tag:
     match: '(@param)\s+(?:({[^}]*}?)\s+)?([a-zA-Z_]\w*)?'
     captures:
       1: { name: storage.type.class.liquid }
       2: { name: entity.name.type.instance.liquid }
       3: { name: variable.other.liquid }
+
+  liquid_doc_example_tag:
+    match: '(@example)\b'
+    captures:
+      1: { name: storage.type.class.liquid }
+
+  liquid_doc_fallback_tag:
+    match: '(@\w+)\b'
+    captures:
+      1: { name: storage.type.class.liquid }
 
   comment_block:
     begin: '{%-?\s*comment\s*-?%}'

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -101,18 +101,17 @@
       },
       "patterns": [
         {
-          "include": "#doc_param"
+          "include": "#liquid_doc_param_tag"
         },
         {
-          "include": "#doc_at_sign"
+          "include": "#liquid_doc_example_tag"
+        },
+        {
+          "include": "#liquid_doc_fallback_tag"
         }
       ]
     },
-    "doc_at_sign": {
-      "match": "@[a-zA-Z]+",
-      "name": "storage.type.class.liquid"
-    },
-    "doc_param": {
+    "liquid_doc_param_tag": {
       "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_]\\w*)?",
       "captures": {
         "1": {
@@ -123,6 +122,22 @@
         },
         "3": {
           "name": "variable.other.liquid"
+        }
+      }
+    },
+    "liquid_doc_example_tag": {
+      "match": "(@example)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      }
+    },
+    "liquid_doc_fallback_tag": {
+      "match": "(@\\w+)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
         }
       }
     },

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -13,6 +13,9 @@
           "include": "#raw_tag"
         },
         {
+          "include": "#doc_tag"
+        },
+        {
           "include": "#comment_block"
         },
         {
@@ -74,6 +77,54 @@
           "match": "(.(?!{%-?\\s*endraw\\s*-?%}))*."
         }
       ]
+    },
+    "doc_tag": {
+      "begin": "{%-?\\s*(doc)\\s*-?%}",
+      "end": "{%-?\\s*(enddoc)\\s*-?%}",
+      "name": "meta.block.doc.liquid",
+      "contentName": "comment.block.documentation.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.liquid"
+        },
+        "1": {
+          "name": "entity.name.tag.doc.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.liquid"
+        },
+        "1": {
+          "name": "entity.name.tag.doc.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#doc_param"
+        },
+        {
+          "include": "#doc_at_sign"
+        }
+      ]
+    },
+    "doc_at_sign": {
+      "match": "@[a-zA-Z]+",
+      "name": "storage.type.class.liquid"
+    },
+    "doc_param": {
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_]\\w*)?",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        },
+        "2": {
+          "name": "entity.name.type.instance.liquid"
+        },
+        "3": {
+          "name": "variable.other.liquid"
+        }
+      }
     },
     "comment_block": {
       "begin": "{%-?\\s*comment\\s*-?%}",

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -27,6 +27,9 @@
           "include": "#raw_tag"
         },
         {
+          "include": "#doc_tag"
+        },
+        {
           "include": "#comment_block"
         },
         {
@@ -88,6 +91,54 @@
           "match": "(.(?!{%-?\\s*endraw\\s*-?%}))*."
         }
       ]
+    },
+    "doc_tag": {
+      "begin": "{%-?\\s*(doc)\\s*-?%}",
+      "end": "{%-?\\s*(enddoc)\\s*-?%}",
+      "name": "meta.block.doc.liquid",
+      "contentName": "comment.block.documentation.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.liquid"
+        },
+        "1": {
+          "name": "entity.name.tag.doc.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.liquid"
+        },
+        "1": {
+          "name": "entity.name.tag.doc.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#doc_param"
+        },
+        {
+          "include": "#doc_at_sign"
+        }
+      ]
+    },
+    "doc_at_sign": {
+      "match": "@[a-zA-Z]+",
+      "name": "storage.type.class.liquid"
+    },
+    "doc_param": {
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_]\\w*)?",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        },
+        "2": {
+          "name": "entity.name.type.instance.liquid"
+        },
+        "3": {
+          "name": "variable.other.liquid"
+        }
+      }
     },
     "comment_block": {
       "begin": "{%-?\\s*comment\\s*-?%}",

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -115,18 +115,17 @@
       },
       "patterns": [
         {
-          "include": "#doc_param"
+          "include": "#liquid_doc_param_tag"
         },
         {
-          "include": "#doc_at_sign"
+          "include": "#liquid_doc_example_tag"
+        },
+        {
+          "include": "#liquid_doc_fallback_tag"
         }
       ]
     },
-    "doc_at_sign": {
-      "match": "@[a-zA-Z]+",
-      "name": "storage.type.class.liquid"
-    },
-    "doc_param": {
+    "liquid_doc_param_tag": {
       "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_]\\w*)?",
       "captures": {
         "1": {
@@ -137,6 +136,22 @@
         },
         "3": {
           "name": "variable.other.liquid"
+        }
+      }
+    },
+    "liquid_doc_example_tag": {
+      "match": "(@example)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      }
+    },
+    "liquid_doc_fallback_tag": {
+      "match": "(@\\w+)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
         }
       }
     },

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -1,0 +1,44 @@
+original file
+-----------------------------------
+{% doc %}
+The default docs
+@param {string} name - The name of the person
+{% enddoc %}
+
+-----------------------------------
+
+Grammar: liquid.tmLanguage.json
+-----------------------------------
+>{% doc %}
+ ^^^
+ text.html.liquid meta.block.doc.liquid meta.tag.liquid
+    ^^^
+    text.html.liquid meta.block.doc.liquid meta.tag.liquid entity.name.tag.doc.liquid
+       ^^^
+       text.html.liquid meta.block.doc.liquid meta.tag.liquid
+>The default docs
+ ^^^^^^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+>@param {string} name - The name of the person
+ ^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+       ^
+       text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+        ^^^^^^^^
+        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid entity.name.type.instance.liquid
+                ^
+                text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+                 ^^^^
+                 text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid variable.other.liquid
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                     text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+>{% enddoc %}
+ ^^^
+ text.html.liquid meta.block.doc.liquid meta.tag.liquid
+    ^^^^^^
+    text.html.liquid meta.block.doc.liquid meta.tag.liquid entity.name.tag.doc.liquid
+          ^^^
+          text.html.liquid meta.block.doc.liquid meta.tag.liquid
+>
+ ^
+ text.html.liquid

--- a/tests/cases/liquid-doc.liquid
+++ b/tests/cases/liquid-doc.liquid
@@ -1,0 +1,4 @@
+{% doc %}
+The default docs
+@param {string} name - The name of the person
+{% enddoc %}


### PR DESCRIPTION
Closes: https://github.com/Shopify/develop-advanced-edits/issues/440

We are introducing a new liquid tag `{% doc %} {% enddoc %}`
It behaves much like JSdoc. This PR adds the highlighting functionality to the tag.

Ex:
![image](https://github.com/user-attachments/assets/dfec1187-c1fa-40b7-8d81-e384e53e6d67)

Added tests for the new tag as well.