### PR TITLE
Add syntax highlighting for LiquidDoc `@description` tag

### DIFF
--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -107,6 +107,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -127,6 +130,14 @@
     },
     "liquid_doc_example_tag": {
       "match": "(@example)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      }
+    },
+    "liquid_doc_description_tag": {
+      "match": "(@description)\\b",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -121,6 +121,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -147,11 +150,19 @@
         }
       }
     },
+    "liquid_doc_description_tag": {
+      "match": "(@description)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      }
+    },
     "liquid_doc_fallback_tag": {
       "match": "(@\\w+)\\b",
       "captures": {
         "1": {
-          "name": "storage.type.class.liquid"
+          "name": "comment.block.liquid"
         }
       }
     },

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -3,6 +3,9 @@ original file
 {% doc %}
 The default docs
 @param {string} name - The name of the person
+@description This is a description
+@example
+{% render 'my-component', name: 'John' %}
 {% enddoc %}
 
 -----------------------------------
@@ -32,6 +35,17 @@ Grammar: liquid.tmLanguage.json
                  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid variable.other.liquid
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+>@description This is a description
+ ^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+             ^^^^^^^^^^^^^^^^^^^^^^^
+             text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+>@example
+ ^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+>{% render 'my-component', name: 'John' %}
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
 >{% enddoc %}
  ^^^
  text.html.liquid meta.block.doc.liquid meta.tag.liquid

--- a/tests/cases/liquid-doc.liquid
+++ b/tests/cases/liquid-doc.liquid
@@ -1,4 +1,7 @@
 {% doc %}
 The default docs
 @param {string} name - The name of the person
+@description This is a description
+@example
+{% render 'my-component', name: 'John' %}
 {% enddoc %}


### PR DESCRIPTION
Closes: https://github.com/Shopify/developer-tools-team/issues/560

## What is this PR doing?
Adding syntax highlighting for the `@description` tag.

I also made a change to the way we highlight `@` tags. 
Originally, so long as you started with `@`, we would highlight what followed as if it were a proper tag. The problem is it could confuse people into assuming they are valid tags and currently we only handle `@param`, `@example`, and `@description`

The change makes anything other than those tags highlight as commented code. The only time we will highlight proper tags is once they are complete. 

Example:
![image](https://github.com/user-attachments/assets/f47881fe-5409-461a-aaa5-dc550e3d00f7)

I'm open for discussion if anyone has thoughts about this implementation.