### PR TITLE
Fix syntax highlighting for param tag & add description tag highlighting

### DIFF
--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -107,6 +107,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -127,6 +130,14 @@
     },
     "liquid_doc_example_tag": {
       "match": "(@example)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      }
+    },
+    "liquid_doc_description_tag": {
+      "match": "(@description)\\b",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -115,7 +115,7 @@
       ]
     },
     "liquid_doc_param_tag": {
-      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_]\\w*)?",
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_][\\w-]*)?(?:\\s+(.*))?",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"
@@ -125,6 +125,9 @@
         },
         "3": {
           "name": "variable.other.liquid"
+        },
+        "4": {
+          "name": "comment.block.liquid"
         }
       }
     },

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -115,7 +115,7 @@
       ]
     },
     "liquid_doc_param_tag": {
-      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_][\\w-]*)?(?:\\s+(.*))?",
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?(\\[?[a-zA-Z_][\\w-]*\\]?)?(?:\\s+(.*))?",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"
@@ -127,23 +127,33 @@
           "name": "variable.other.liquid"
         },
         "4": {
-          "name": "comment.block.liquid"
+          "name": "string.quoted.single.liquid"
         }
       }
     },
     "liquid_doc_example_tag": {
-      "match": "(@example)\\b",
-      "captures": {
+    "begin": "(@example)\\b\\s*",
+    "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "beginCaptures": {
         "1": {
           "name": "storage.type.class.liquid"
         }
-      }
+      },
+      "contentName": "string.quoted.single.liquid",
+      "patterns": [
+        {
+          "match": "(.(?!@|{%-?\\s*enddoc\\s*-?%}))*."
+        }
+      ]
     },
     "liquid_doc_description_tag": {
-      "match": "(@description)\\b",
+      "match": "(@description)\\b(?:\\s+(.*))?",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"
+        },
+        "2": {
+          "name": "string.quoted.single.liquid"
         }
       }
     },

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -121,6 +121,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -147,11 +150,19 @@
         }
       }
     },
+    "liquid_doc_description_tag": {
+      "match": "(@description)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      }
+    },
     "liquid_doc_fallback_tag": {
       "match": "(@\\w+)\\b",
       "captures": {
         "1": {
-          "name": "storage.type.class.liquid"
+          "name": "comment.block.liquid"
         }
       }
     },

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -129,7 +129,7 @@
       ]
     },
     "liquid_doc_param_tag": {
-      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_]\\w*)?",
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_][\\w-]*)?(?:\\s+(.*))?",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"
@@ -139,6 +139,9 @@
         },
         "3": {
           "name": "variable.other.liquid"
+        },
+        "4": {
+          "name": "comment.block.liquid"
         }
       }
     },

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -129,7 +129,7 @@
       ]
     },
     "liquid_doc_param_tag": {
-      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?([a-zA-Z_][\\w-]*)?(?:\\s+(.*))?",
+      "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?(\\[?[a-zA-Z_][\\w-]*\\]?)?(?:\\s+(.*))?",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"
@@ -141,23 +141,33 @@
           "name": "variable.other.liquid"
         },
         "4": {
-          "name": "comment.block.liquid"
+          "name": "string.quoted.single.liquid"
         }
       }
     },
     "liquid_doc_example_tag": {
-      "match": "(@example)\\b",
-      "captures": {
+    "begin": "(@example)\\b\\s*",
+    "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "beginCaptures": {
         "1": {
           "name": "storage.type.class.liquid"
         }
-      }
+      },
+      "contentName": "string.quoted.single.liquid",
+      "patterns": [
+        {
+          "match": "(.(?!@|{%-?\\s*enddoc\\s*-?%}))*."
+        }
+      ]
     },
     "liquid_doc_description_tag": {
-      "match": "(@description)\\b",
+      "match": "(@description)\\b(?:\\s+(.*))?",
       "captures": {
         "1": {
           "name": "storage.type.class.liquid"
+        },
+        "2": {
+          "name": "string.quoted.single.liquid"
         }
       }
     },

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -33,8 +33,10 @@ Grammar: liquid.tmLanguage.json
                 text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
                  ^^^^
                  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid variable.other.liquid
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                     ^
                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+                      ^^^^^^^^^^^^^^^^^^^^^^^^
+                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.liquid
 >@description This is a description
  ^^^^^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -36,25 +36,59 @@ Grammar: liquid.tmLanguage.json
                      ^
                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
                       ^^^^^^^^^^^^^^^^^^^^^^^^
-                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.liquid
+                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >@description This is a description
  ^^^^^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
-             ^^^^^^^^^^^^^^^^^^^^^^^
+             ^
              text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+              ^^^^^^^^^^^^^^^^^^^^^
+              text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >@example
  ^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
 >{% render 'my-component', name: 'John' %}
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
->{% enddoc %}
- ^^^
- text.html.liquid meta.block.doc.liquid meta.tag.liquid
+ ^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+   ^
+   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
     ^^^^^^
-    text.html.liquid meta.block.doc.liquid meta.tag.liquid entity.name.tag.doc.liquid
-          ^^^
-          text.html.liquid meta.block.doc.liquid meta.tag.liquid
+    text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid entity.name.tag.render.liquid
+          ^
+          text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
+           ^
+           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+            ^^^^^^^^^^^^
+            text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                        ^
+                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                         ^^
+                         text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
+                           ^^^^^
+                           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid entity.other.attribute-name.liquid
+                                ^
+                                text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
+                                 ^
+                                 text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                                  ^^^^
+                                  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                                      ^
+                                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                                       ^
+                                       text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
+                                        ^^
+                                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+>{% enddoc %}
+ ^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+   ^
+   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.liquid
+    ^^^^^^
+    text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.liquid entity.name.tag.liquid
+          ^
+          text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.liquid
+           ^^
+           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
 >
  ^
- text.html.liquid
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -3,6 +3,9 @@ original file
 {% doc %}
 The default docs
 @param {string} name - The name of the person
+@description This is a description
+@example
+{% render 'my-component', name: 'John' %}
 {% enddoc %}
 
 -----------------------------------
@@ -32,6 +35,17 @@ Grammar: liquid.tmLanguage.json
                  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid variable.other.liquid
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+>@description This is a description
+ ^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+             ^^^^^^^^^^^^^^^^^^^^^^^
+             text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+>@example
+ ^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+>{% render 'my-component', name: 'John' %}
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
 >{% enddoc %}
  ^^^
  text.html.liquid meta.block.doc.liquid meta.tag.liquid

--- a/tests/cases/liquid-doc.liquid
+++ b/tests/cases/liquid-doc.liquid
@@ -1,4 +1,7 @@
 {% doc %}
 The default docs
 @param {string} name - The name of the person
+@description This is a description
+@example
+{% render 'my-component', name: 'John' %}
 {% enddoc %}


### PR DESCRIPTION
Closes: https://github.com/Shopify/developer-tools-team/issues/557

## What is this PR doing?
Add highlighting for the `@description` tag.

There was a syntax highlighting error when you would have a hyphen in a variable name before the hyphen used to show a description in a param tag.

For example"
`@param {String} title - The title of the product` would properly highlight the code.
`@param {String} my-title - The title of the product` would stop highlighting properly after `my-`

This is because we were matching on the first hyphen found. I've reworked the matching and now we look for the first space after the variable name. This is a lot more robust.

The changes work even if you don't add the variable type such as `{String}`

Before: 
![image](https://github.com/user-attachments/assets/9f19a904-a164-4fee-9859-fecc26faeb63)


After:
![image](https://github.com/user-attachments/assets/3629d997-b875-4879-829e-d921c7baef2c)

