### PR TITLE
Fixes to liquiddoc syntax highlighting

### DIFF
--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -132,30 +132,32 @@
       }
     },
     "liquid_doc_example_tag": {
-    "begin": "(@example)\\b\\s*",
-    "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "begin": "(@example)\\b\\s*",
       "beginCaptures": {
-        "1": {
-          "name": "storage.type.class.liquid"
-        }
+        "0": { "name": "comment.block.documentation.liquid" },
+        "1": { "name": "storage.type.class.liquid" }
       },
-      "contentName": "string.quoted.single.liquid",
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
         {
-          "match": "(.(?!@|{%-?\\s*enddoc\\s*-?%}))*."
+          "match": "[^@{%]+",
+          "name": "string.quoted.single.liquid"
         }
       ]
     },
     "liquid_doc_description_tag": {
-      "match": "(@description)\\b(?:\\s+(.*))?",
-      "captures": {
-        "1": {
-          "name": "storage.type.class.liquid"
-        },
-        "2": {
+      "begin": "(@description)\\b\\s*",
+      "beginCaptures": {
+        "0": { "name": "comment.block.documentation.liquid" },
+        "1": { "name": "storage.type.class.liquid" }
+      },
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "patterns": [
+        {
+          "match": "[^@{%]+",
           "name": "string.quoted.single.liquid"
         }
-      }
+      ]
     },
     "liquid_doc_fallback_tag": {
       "match": "(@\\w+)\\b",

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -146,30 +146,32 @@
       }
     },
     "liquid_doc_example_tag": {
-    "begin": "(@example)\\b\\s*",
-    "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "begin": "(@example)\\b\\s*",
       "beginCaptures": {
-        "1": {
-          "name": "storage.type.class.liquid"
-        }
+        "0": { "name": "comment.block.documentation.liquid" },
+        "1": { "name": "storage.type.class.liquid" }
       },
-      "contentName": "string.quoted.single.liquid",
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
         {
-          "match": "(.(?!@|{%-?\\s*enddoc\\s*-?%}))*."
+          "match": "[^@{%]+",
+          "name": "string.quoted.single.liquid"
         }
       ]
     },
     "liquid_doc_description_tag": {
-      "match": "(@description)\\b(?:\\s+(.*))?",
-      "captures": {
-        "1": {
-          "name": "storage.type.class.liquid"
-        },
-        "2": {
+      "begin": "(@description)\\b\\s*",
+      "beginCaptures": {
+        "0": { "name": "comment.block.documentation.liquid" },
+        "1": { "name": "storage.type.class.liquid" }
+      },
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "patterns": [
+        {
+          "match": "[^@{%]+",
           "name": "string.quoted.single.liquid"
         }
-      }
+      ]
     },
     "liquid_doc_fallback_tag": {
       "match": "(@\\w+)\\b",

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -39,56 +39,30 @@ Grammar: liquid.tmLanguage.json
                       text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >@description This is a description
  ^^^^^^^^^^^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
              ^
-             text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
-              ^^^^^^^^^^^^^^^^^^^^^
+             text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid
+              ^^^^^^^^^^^^^^^^^^^^^^
               text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >@example
  ^^^^^^^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid storage.type.class.liquid
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
 >{% render 'my-component', name: 'John' %}
  ^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
-   ^
-   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
-    ^^^^^^
-    text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid entity.name.tag.render.liquid
-          ^
-          text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
-           ^
-           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
-            ^^^^^^^^^^^^
-            text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
-                        ^
-                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
-                         ^^
-                         text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
-                           ^^^^^
-                           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid entity.other.attribute-name.liquid
-                                ^
-                                text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
-                                 ^
-                                 text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
-                                  ^^^^
-                                  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
-                                      ^
-                                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
-                                       ^
-                                       text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.render.liquid
-                                        ^^
-                                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+                                        ^
+                                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
+                                         ^^
+                                         text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >{% enddoc %}
- ^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
-   ^
-   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.liquid
+ ^^^
+ text.html.liquid meta.block.doc.liquid meta.tag.liquid
     ^^^^^^
-    text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.liquid entity.name.tag.liquid
-          ^
-          text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid meta.entity.tag.liquid
-           ^^
-           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+    text.html.liquid meta.block.doc.liquid meta.tag.liquid entity.name.tag.doc.liquid
+          ^^^
+          text.html.liquid meta.block.doc.liquid meta.tag.liquid
 >
  ^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+ text.html.liquid


### PR DESCRIPTION
This PR addresses a few issues with syntax highlighting.

1. If a description was multi line, it would not properly highlight
2. If a description OR example tag were the last tags before an `{% enddoc %}` tag, the `{% enddoc %} tag would be improperly highlighted.

Before:
![image](https://github.com/user-attachments/assets/9916094b-f927-4202-81d2-d2eae32f8a3f)


After:
![image](https://github.com/user-attachments/assets/8db554f3-d786-46b2-832a-c32f45915f1c)


The fixes should be more robust, and we were able to switch from a negative lookahead to a cleaner matching system.
