### PR TITLE
Fixes liquiddoc special character highlight

### DIFF
--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -140,7 +140,7 @@
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
         {
-          "match": "[^@{%]+",
+          "match": "[^@]+",
           "name": "string.quoted.single.liquid"
         }
       ]
@@ -154,7 +154,7 @@
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
         {
-          "match": "[^@{%]+",
+          "match": "[^@]+",
           "name": "string.quoted.single.liquid"
         }
       ]

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -154,7 +154,7 @@
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
         {
-          "match": "[^@{%]+",
+          "match": "[^@]+",
           "name": "string.quoted.single.liquid"
         }
       ]
@@ -168,7 +168,7 @@
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
         {
-          "match": "[^@{%]+",
+          "match": "[^@]+",
           "name": "string.quoted.single.liquid"
         }
       ]

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -48,14 +48,8 @@ Grammar: liquid.tmLanguage.json
  ^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
 >{% render 'my-component', name: 'John' %}
- ^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
-   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
-                                        ^
-                                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
-                                         ^^
-                                         text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >{% enddoc %}
  ^^^
  text.html.liquid meta.block.doc.liquid meta.tag.liquid


### PR DESCRIPTION
Update the description and example area of liquid doc to include `{` and `%` characters

before:
<img width="745" alt="image" src="https://github.com/user-attachments/assets/19cc5047-56fc-4eac-b0a0-13ccfdf2708d" />


after:
<img width="745" alt="image" src="https://github.com/user-attachments/assets/e5b2cb69-4995-43f1-a6e3-a07be4f75788" />

