### PR TITLE
Update liquiddoc rules in base-syntax

### DIFF
--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -46,26 +46,43 @@ repository:
       0: { name: meta.tag.liquid }
       1: { name: entity.name.tag.doc.liquid }
     patterns:
+      - include: '#liquid_doc_description_tag'
       - include: '#liquid_doc_param_tag'
       - include: '#liquid_doc_example_tag'
       - include: '#liquid_doc_fallback_tag'
 
+  liquid_doc_description_tag:
+    begin: '(@description)\b\s*'
+    beginCaptures:
+      0: { "name": comment.block.documentation.liquid }
+      1: { "name": storage.type.class.liquid }
+    end: '(?=@|{%-?\s*enddoc\s*-?%})'
+    patterns:
+      - match: '[^@]+'
+        name: string.quoted.single.liquid
+
   liquid_doc_param_tag:
-    match: '(@param)\s+(?:({[^}]*}?)\s+)?([a-zA-Z_]\w*)?'
+    match: '(@param)\s+(?:({[^}]*}?)\s+)?(\[?[a-zA-Z_][\w-]*\]?)?(?:\s+(.*))?'
     captures:
       1: { name: storage.type.class.liquid }
       2: { name: entity.name.type.instance.liquid }
       3: { name: variable.other.liquid }
+      4: { name: string.quoted.single.liquid }
 
   liquid_doc_example_tag:
-    match: '(@example)\b'
-    captures:
+    begin: '(@example)\b\s*'
+    beginCaptures:
+      0: { name: comment.block.documentation.liquid }
       1: { name: storage.type.class.liquid }
+    end: '(?=@|{%-?\s*enddoc\s*-?%})'
+    patterns:
+      - match: '[^@]+'
+        name: string.quoted.single.liquid
 
   liquid_doc_fallback_tag:
     match: '(@\w+)\b'
     captures:
-      1: { name: storage.type.class.liquid }
+      1: { name: comment.block.liquid }
 
   comment_block:
     begin: '{%-?\s*comment\s*-?%}'

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -101,16 +101,34 @@
       },
       "patterns": [
         {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
           "include": "#liquid_doc_param_tag"
         },
         {
           "include": "#liquid_doc_example_tag"
         },
         {
-          "include": "#liquid_doc_description_tag"
-        },
-        {
           "include": "#liquid_doc_fallback_tag"
+        }
+      ]
+    },
+    "liquid_doc_description_tag": {
+      "begin": "(@description)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "patterns": [
+        {
+          "match": "[^@]+",
+          "name": "string.quoted.single.liquid"
         }
       ]
     },
@@ -134,22 +152,12 @@
     "liquid_doc_example_tag": {
       "begin": "(@example)\\b\\s*",
       "beginCaptures": {
-        "0": { "name": "comment.block.documentation.liquid" },
-        "1": { "name": "storage.type.class.liquid" }
-      },
-      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
-      "patterns": [
-        {
-          "match": "[^@]+",
-          "name": "string.quoted.single.liquid"
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
         }
-      ]
-    },
-    "liquid_doc_description_tag": {
-      "begin": "(@description)\\b\\s*",
-      "beginCaptures": {
-        "0": { "name": "comment.block.documentation.liquid" },
-        "1": { "name": "storage.type.class.liquid" }
       },
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [
@@ -163,7 +171,7 @@
       "match": "(@\\w+)\\b",
       "captures": {
         "1": {
-          "name": "storage.type.class.liquid"
+          "name": "comment.block.liquid"
         }
       }
     },

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -115,16 +115,34 @@
       },
       "patterns": [
         {
+          "include": "#liquid_doc_description_tag"
+        },
+        {
           "include": "#liquid_doc_param_tag"
         },
         {
           "include": "#liquid_doc_example_tag"
         },
         {
-          "include": "#liquid_doc_description_tag"
-        },
-        {
           "include": "#liquid_doc_fallback_tag"
+        }
+      ]
+    },
+    "liquid_doc_description_tag": {
+      "begin": "(@description)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "patterns": [
+        {
+          "match": "[^@]+",
+          "name": "string.quoted.single.liquid"
         }
       ]
     },
@@ -148,22 +166,12 @@
     "liquid_doc_example_tag": {
       "begin": "(@example)\\b\\s*",
       "beginCaptures": {
-        "0": { "name": "comment.block.documentation.liquid" },
-        "1": { "name": "storage.type.class.liquid" }
-      },
-      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
-      "patterns": [
-        {
-          "match": "[^@]+",
-          "name": "string.quoted.single.liquid"
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
         }
-      ]
-    },
-    "liquid_doc_description_tag": {
-      "begin": "(@description)\\b\\s*",
-      "beginCaptures": {
-        "0": { "name": "comment.block.documentation.liquid" },
-        "1": { "name": "storage.type.class.liquid" }
       },
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
       "patterns": [


### PR DESCRIPTION
We incorrectly updated `grammars/liquid-injection.tmLanguage.json` and `grammars/liquid.tmLanguage.json` manually rather than updating `base-syntax.yml`.

This updates base-syntax instead, and builds the json files using the commands in `package.json`