### PR TITLE
Example content highlighting change

### DIFF
--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -75,9 +75,9 @@ repository:
       0: { name: comment.block.documentation.liquid }
       1: { name: storage.type.class.liquid }
     end: '(?=@|{%-?\s*enddoc\s*-?%})'
+    contentName: meta.embedded.block.liquid
     patterns:
-      - match: '[^@]+'
-        name: string.quoted.single.liquid
+      - include: '#core'
 
   liquid_doc_fallback_tag:
     match: '(@\w+)\b'

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -160,10 +160,10 @@
         }
       },
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "meta.embedded.block.liquid",
       "patterns": [
         {
-          "match": "[^@]+",
-          "name": "string.quoted.single.liquid"
+          "include": "#core"
         }
       ]
     },

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -174,10 +174,10 @@
         }
       },
       "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "meta.embedded.block.liquid",
       "patterns": [
         {
-          "match": "[^@]+",
-          "name": "string.quoted.single.liquid"
+          "include": "#core"
         }
       ]
     },

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -48,8 +48,36 @@ Grammar: liquid.tmLanguage.json
  ^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
 >{% render 'my-component', name: 'John' %}
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+ ^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid punctuation.definition.tag.begin.liquid
+   ^
+   text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid
+    ^^^^^^
+    text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid entity.name.tag.render.liquid
+          ^
+          text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid
+           ^
+           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+            ^^^^^^^^^^^^
+            text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                        ^
+                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                         ^^
+                         text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid
+                           ^^^^^
+                           text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid entity.other.attribute-name.liquid
+                                ^
+                                text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid
+                                 ^
+                                 text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                                  ^^^^
+                                  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                                      ^
+                                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid string.quoted.single.liquid
+                                       ^
+                                       text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid meta.entity.tag.render.liquid
+                                        ^^
+                                        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid meta.embedded.block.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
 >{% enddoc %}
  ^^^
  text.html.liquid meta.block.doc.liquid meta.tag.liquid


### PR DESCRIPTION
Allow `@example` content to highlight under the liquid rules.

Before:
![image](https://github.com/user-attachments/assets/c9717d7f-8851-4c8d-867d-8788900c69d4)

After:
![image](https://github.com/user-attachments/assets/81759f0c-3e65-4a52-8f49-148dd3a6105a)

Follow up [issue](https://github.com/Shopify/developer-tools-team/issues/614):
Free form text will show differently as we pick up anything in `@example` as liquid for highlighting. We can follow up with a PR for that free form text to show as `string.quoted.single.liquid` which is the same as `@description` content, and what `@example` content was prior.