### PR TITLE
added free form text pattern to use with example content

### DIFF
--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -77,12 +77,24 @@ repository:
     end: '(?=@|{%-?\s*enddoc\s*-?%})'
     contentName: meta.embedded.block.liquid
     patterns:
-      - include: '#core'
+      - include: '#raw_tag'
+      - include: '#style_codefence'
+      - include: '#stylesheet_codefence'
+      - include: '#json_codefence'
+      - include: '#javascript_codefence'
+      - include: '#object'
+      - include: '#tag'
+      - include: '#free_form_text'
+      - include: text.html.basic
 
   liquid_doc_fallback_tag:
     match: '(@\w+)\b'
     captures:
       1: { name: comment.block.liquid }
+
+  free_form_text:
+    match: '(?:(?![{<]).)+'
+    name: string.quoted.single.liquid
 
   comment_block:
     begin: '{%-?\s*comment\s*-?%}'

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -163,7 +163,31 @@
       "contentName": "meta.embedded.block.liquid",
       "patterns": [
         {
-          "include": "#core"
+          "include": "#raw_tag"
+        },
+        {
+          "include": "#style_codefence"
+        },
+        {
+          "include": "#stylesheet_codefence"
+        },
+        {
+          "include": "#json_codefence"
+        },
+        {
+          "include": "#javascript_codefence"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#tag"
+        },
+        {
+          "include": "#free_form_text"
+        },
+        {
+          "include": "text.html.basic"
         }
       ]
     },
@@ -174,6 +198,10 @@
           "name": "comment.block.liquid"
         }
       }
+    },
+    "free_form_text": {
+      "match": "(?:(?![{<]).)+",
+      "name": "string.quoted.single.liquid"
     },
     "comment_block": {
       "begin": "{%-?\\s*comment\\s*-?%}",

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -177,7 +177,31 @@
       "contentName": "meta.embedded.block.liquid",
       "patterns": [
         {
-          "include": "#core"
+          "include": "#raw_tag"
+        },
+        {
+          "include": "#style_codefence"
+        },
+        {
+          "include": "#stylesheet_codefence"
+        },
+        {
+          "include": "#json_codefence"
+        },
+        {
+          "include": "#javascript_codefence"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#tag"
+        },
+        {
+          "include": "#free_form_text"
+        },
+        {
+          "include": "text.html.basic"
         }
       ]
     },
@@ -188,6 +212,10 @@
           "name": "comment.block.liquid"
         }
       }
+    },
+    "free_form_text": {
+      "match": "(?:(?![{<]).)+",
+      "name": "string.quoted.single.liquid"
     },
     "comment_block": {
       "begin": "{%-?\\s*comment\\s*-?%}",


### PR DESCRIPTION
Closes: https://github.com/Shopify/developer-tools-team/issues/614

Adds proper highlighting for free form text pattern for `@example` that aligns with `@description` and `@param` tags

Before:
![image](https://github.com/user-attachments/assets/f916e950-2a3d-4446-bb93-6007ab0a145a)

After: 
![image](https://github.com/user-attachments/assets/b16a21c1-8462-4d9e-bdc2-3cc70c235434)
