### PR TITLE
Added syntax highlighting for the prompt tag

### DIFF
--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -49,6 +49,7 @@ repository:
       - include: '#liquid_doc_description_tag'
       - include: '#liquid_doc_param_tag'
       - include: '#liquid_doc_example_tag'
+      - include: '#liquid_doc_prompt_tag'
       - include: '#liquid_doc_fallback_tag'
 
   liquid_doc_description_tag:
@@ -78,6 +79,17 @@ repository:
     contentName: meta.embedded.block.liquid
     patterns:
       - include: '#core'
+
+  liquid_doc_prompt_tag:
+    begin: '(@prompt)\b\s*'
+    beginCaptures:
+      0: { "name": comment.block.documentation.liquid }
+      1: { "name": storage.type.class.liquid }
+    end: '(?=@|{%-?\s*enddoc\s*-?%})'
+    patterns:
+      - match: '[^@]+'
+        name: string.quoted.single.liquid
+
 
   liquid_doc_fallback_tag:
     match: '(@\w+)\b'

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -110,6 +110,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_prompt_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -164,6 +167,24 @@
       "patterns": [
         {
           "include": "#core"
+        }
+      ]
+    },
+    "liquid_doc_prompt_tag": {
+      "begin": "(@prompt)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "patterns": [
+        {
+          "match": "[^@]+",
+          "name": "string.quoted.single.liquid"
         }
       ]
     },

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -124,6 +124,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_prompt_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -178,6 +181,24 @@
       "patterns": [
         {
           "include": "#core"
+        }
+      ]
+    },
+    "liquid_doc_prompt_tag": {
+      "begin": "(@prompt)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "patterns": [
+        {
+          "match": "[^@]+",
+          "name": "string.quoted.single.liquid"
         }
       ]
     },

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -4,6 +4,7 @@ original file
 The default docs
 @param {string} name - The name of the person
 @description This is a description
+@prompt "What is the name of the person?"
 @example
 {% render 'my-component', name: 'John' %}
 {% enddoc %}
@@ -44,6 +45,13 @@ Grammar: liquid.tmLanguage.json
              text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid
               ^^^^^^^^^^^^^^^^^^^^^^
               text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+>@prompt "What is the name of the person?"
+ ^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
+        ^
+        text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >@example
  ^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid

--- a/tests/cases/liquid-doc.liquid
+++ b/tests/cases/liquid-doc.liquid
@@ -2,6 +2,7 @@
 The default docs
 @param {string} name - The name of the person
 @description This is a description
+@prompt "What is the name of the person?"
 @example
 {% render 'my-component', name: 'John' %}
 {% enddoc %}


### PR DESCRIPTION
Closes: https://github.com/Shopify/developer-tools-team/issues/652

Add syntax highlighting for the `prompt` tag in liquid doc.

![image](https://github.com/user-attachments/assets/749a860e-21b4-42d1-b56d-54efdd194cd1)

The `prompt` tag mimics the same highlighting rules as the `description` tag. I kept them as separate rules in case we decide to change how we highlight this tag in the future.