### PR TITLE
Update syntax highlighting for free-form liquid-doc tags

### DIFF
--- a/base-syntax.yml
+++ b/base-syntax.yml
@@ -49,17 +49,16 @@ repository:
       - include: '#liquid_doc_description_tag'
       - include: '#liquid_doc_param_tag'
       - include: '#liquid_doc_example_tag'
+      - include: '#liquid_doc_prompt_tag'
       - include: '#liquid_doc_fallback_tag'
 
   liquid_doc_description_tag:
     begin: '(@description)\b\s*'
     beginCaptures:
-      0: { "name": comment.block.documentation.liquid }
-      1: { "name": storage.type.class.liquid }
-    end: '(?=@|{%-?\s*enddoc\s*-?%})'
-    patterns:
-      - match: '[^@]+'
-        name: string.quoted.single.liquid
+      0: { name: comment.block.documentation.liquid }
+      1: { name: storage.type.class.liquid }
+    end: '(?=@prompt|@example|@param|@description|{%-?\s*enddoc\s*-?%})'
+    contentName: string.quoted.single.liquid
 
   liquid_doc_param_tag:
     match: '(@param)\s+(?:({[^}]*}?)\s+)?(\[?[a-zA-Z_][\w-]*\]?)?(?:\s+(.*))?'
@@ -74,10 +73,18 @@ repository:
     beginCaptures:
       0: { name: comment.block.documentation.liquid }
       1: { name: storage.type.class.liquid }
-    end: '(?=@|{%-?\s*enddoc\s*-?%})'
+    end: '(?=@prompt|@example|@param|@description|{%-?\s*enddoc\s*-?%})'
     contentName: meta.embedded.block.liquid
     patterns:
       - include: '#core'
+
+  liquid_doc_prompt_tag:
+    begin: '(@prompt)\b\s*'
+    beginCaptures:
+      0: { name: comment.block.documentation.liquid }
+      1: { name: storage.type.class.liquid }
+    end: '(?=@prompt|@example|@param|@description|{%-?\s*enddoc\s*-?%})'
+    contentName: string.quoted.single.liquid
 
   liquid_doc_fallback_tag:
     match: '(@\w+)\b'
@@ -545,7 +552,7 @@ repository:
 
   value_expression:
     patterns:
-        # TODO ???
+      # TODO ???
       - match: '(\[)(\|)(?=[^\]]*)(?=\])'
         captures:
           '2': { name: invalid.illegal.filter.liquid }
@@ -565,7 +572,7 @@ repository:
 
   variable_lookup:
     patterns:
-        # Stuff provided by the language has its own colour
+      # Stuff provided by the language has its own colour
       - match: \b(<%= ANY_GLOBAL_OBJECT %>)\b
         name: variable.language.liquid
 

--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -110,6 +110,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_prompt_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -124,13 +127,8 @@
           "name": "storage.type.class.liquid"
         }
       },
-      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
-      "patterns": [
-        {
-          "match": "[^@]+",
-          "name": "string.quoted.single.liquid"
-        }
-      ]
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "string.quoted.single.liquid"
     },
     "liquid_doc_param_tag": {
       "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?(\\[?[a-zA-Z_][\\w-]*\\]?)?(?:\\s+(.*))?",
@@ -159,13 +157,26 @@
           "name": "storage.type.class.liquid"
         }
       },
-      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
       "contentName": "meta.embedded.block.liquid",
       "patterns": [
         {
           "include": "#core"
         }
       ]
+    },
+    "liquid_doc_prompt_tag": {
+      "begin": "(@prompt)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "string.quoted.single.liquid"
     },
     "liquid_doc_fallback_tag": {
       "match": "(@\\w+)\\b",

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -124,6 +124,9 @@
           "include": "#liquid_doc_example_tag"
         },
         {
+          "include": "#liquid_doc_prompt_tag"
+        },
+        {
           "include": "#liquid_doc_fallback_tag"
         }
       ]
@@ -138,13 +141,8 @@
           "name": "storage.type.class.liquid"
         }
       },
-      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
-      "patterns": [
-        {
-          "match": "[^@]+",
-          "name": "string.quoted.single.liquid"
-        }
-      ]
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "string.quoted.single.liquid"
     },
     "liquid_doc_param_tag": {
       "match": "(@param)\\s+(?:({[^}]*}?)\\s+)?(\\[?[a-zA-Z_][\\w-]*\\]?)?(?:\\s+(.*))?",
@@ -173,13 +171,26 @@
           "name": "storage.type.class.liquid"
         }
       },
-      "end": "(?=@|{%-?\\s*enddoc\\s*-?%})",
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
       "contentName": "meta.embedded.block.liquid",
       "patterns": [
         {
           "include": "#core"
         }
       ]
+    },
+    "liquid_doc_prompt_tag": {
+      "begin": "(@prompt)\\b\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "comment.block.documentation.liquid"
+        },
+        "1": {
+          "name": "storage.type.class.liquid"
+        }
+      },
+      "end": "(?=@prompt|@example|@param|@description|{%-?\\s*enddoc\\s*-?%})",
+      "contentName": "string.quoted.single.liquid"
     },
     "liquid_doc_fallback_tag": {
       "match": "(@\\w+)\\b",

--- a/tests/baselines/liquid-doc.baseline.txt
+++ b/tests/baselines/liquid-doc.baseline.txt
@@ -3,7 +3,10 @@ original file
 {% doc %}
 The default docs
 @param {string} name - The name of the person
-@description This is a description
+@description This is a description with an @ inside
+@this should be unrecognized and highlighted as part of the description body
+@prompt
+    What is the name of the person?
 @example
 {% render 'my-component', name: 'John' %}
 {% enddoc %}
@@ -37,13 +40,22 @@ Grammar: liquid.tmLanguage.json
                      text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid
                       ^^^^^^^^^^^^^^^^^^^^^^^^
                       text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
->@description This is a description
+>@description This is a description with an @ inside
  ^^^^^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
              ^
              text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid
-              ^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+>@this should be unrecognized and highlighted as part of the description body
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
+>@prompt
+ ^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid
+>    What is the name of the person?
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid string.quoted.single.liquid
 >@example
  ^^^^^^^^
  text.html.liquid meta.block.doc.liquid comment.block.documentation.liquid comment.block.documentation.liquid storage.type.class.liquid

--- a/tests/cases/liquid-doc.liquid
+++ b/tests/cases/liquid-doc.liquid
@@ -1,7 +1,10 @@
 {% doc %}
 The default docs
 @param {string} name - The name of the person
-@description This is a description
+@description This is a description with an @ inside
+@this should be unrecognized and highlighted as part of the description body
+@prompt
+    What is the name of the person?
 @example
 {% render 'my-component', name: 'John' %}
 {% enddoc %}


### PR DESCRIPTION
Closes https://github.com/Shopify/developer-tools-team/issues/689

- Accepts `@` in the content body of free-form tags (`prompt`, `description`, `example`)
# Before
<img width="743" alt="image" src="https://github.com/user-attachments/assets/7d9136b1-c067-45d9-9d54-0b9f170b71eb" />

# After
![image](https://github.com/user-attachments/assets/1f368fc4-37d5-4cbe-9ead-db8225d76d73)


