### PR TITLE
Support inline snippets tag

### DIFF
--- a/grammars/liquid-injection.tmLanguage.json
+++ b/grammars/liquid-injection.tmLanguage.json
@@ -800,7 +800,7 @@
           }
         },
         {
-          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(capture|case|comment|for|form|if|javascript|paginate|schema|style)\\b",
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(capture|case|comment|for|form|if|javascript|paginate|schema|snippet|style)\\b",
           "captures": {
             "1": {
               "name": "keyword.control.other.liquid"
@@ -808,7 +808,7 @@
           }
         },
         {
-          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\\b",
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endsnippet|endstyle)\\b",
           "captures": {
             "1": {
               "name": "keyword.control.other.liquid"

--- a/grammars/liquid.tmLanguage.json
+++ b/grammars/liquid.tmLanguage.json
@@ -4,8 +4,8 @@
   "fileTypes": [
     "liquid"
   ],
-  "foldingStartMarker": "(?x)\n{%\n  -?\n  \\s*\n  (capture|case|comment|for|form|if|javascript|paginate|schema|style)\n  [^(%})]+\n%}\n",
-  "foldingStopMarker": "(?x)\n{%\n  \\s*\n  (endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\n  [^(%})]+\n%}\n",
+  "foldingStartMarker": "(?x)\n{%\n  -?\n  \\s*\n  (capture|case|comment|for|form|if|javascript|paginate|schema|snippet|style)\n  [^(%})]+\n%}\n",
+  "foldingStopMarker": "(?x)\n{%\n  \\s*\n  (endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endsnippet|endstyle)\n  [^(%})]+\n%}\n",
   "injections": {
     "L:meta.embedded.block.js, L:meta.embedded.block.css, L:meta.embedded.block.html, L:string.quoted": {
       "patterns": [
@@ -814,7 +814,7 @@
           }
         },
         {
-          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(capture|case|comment|for|form|if|javascript|paginate|schema|style)\\b",
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(capture|case|comment|for|form|if|javascript|paginate|schema|snippet|style)\\b",
           "captures": {
             "1": {
               "name": "keyword.control.other.liquid"
@@ -822,7 +822,7 @@
           }
         },
         {
-          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\\b",
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endsnippet|endstyle)\\b",
           "captures": {
             "1": {
               "name": "keyword.control.other.liquid"

--- a/liquid/tags.yml
+++ b/liquid/tags.yml
@@ -24,6 +24,7 @@
 - schema: endschema
 - section
 - sections
+- snippet: endsnippet
 - style: endstyle
 - stylesheet
 - tablerow

--- a/tests/baselines/tag-snippet.baseline.txt
+++ b/tests/baselines/tag-snippet.baseline.txt
@@ -1,0 +1,48 @@
+original file
+-----------------------------------
+{% snippet about_me %}
+  I am {{ age }}
+{% endsnippet %}
+
+-----------------------------------
+
+Grammar: liquid.tmLanguage.json
+-----------------------------------
+>{% snippet about_me %}
+ ^^
+ text.html.liquid meta.tag.liquid punctuation.definition.tag.begin.liquid
+   ^
+   text.html.liquid meta.tag.liquid
+    ^^^^^^^
+    text.html.liquid meta.tag.liquid keyword.control.other.liquid
+           ^^^^^^^^^^
+           text.html.liquid meta.tag.liquid
+                     ^^
+                     text.html.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+>  I am {{ age }}
+ ^^^^^^^
+ text.html.liquid
+        ^^
+        text.html.liquid meta.object.liquid punctuation.definition.tag.begin.liquid
+          ^
+          text.html.liquid meta.object.liquid
+           ^^^
+           text.html.liquid meta.object.liquid variable.other.liquid
+              ^
+              text.html.liquid meta.object.liquid
+               ^^
+               text.html.liquid meta.object.liquid punctuation.definition.tag.end.liquid
+>{% endsnippet %}
+ ^^
+ text.html.liquid meta.tag.liquid punctuation.definition.tag.begin.liquid
+   ^
+   text.html.liquid meta.tag.liquid
+    ^^^^^^^^^^
+    text.html.liquid meta.tag.liquid keyword.control.other.liquid
+              ^
+              text.html.liquid meta.tag.liquid
+               ^^
+               text.html.liquid meta.tag.liquid punctuation.definition.tag.end.liquid
+>
+ ^
+ text.html.liquid

--- a/tests/cases/tag-snippet.liquid
+++ b/tests/cases/tag-snippet.liquid
@@ -1,0 +1,3 @@
+{% snippet about_me %}
+  I am {{ age }}
+{% endsnippet %}


### PR DESCRIPTION
related to: https://github.com/Shopify/developer-tools-team/issues/821?reload=1

A new inline snippets tag is being introduced and it should be highlighted similarly to other liquid tags like `capture`

<img width="501" height="93" alt="inline-snippets" src="https://github.com/user-attachments/assets/8c317603-87e3-4bc9-a87d-f39d369e7fd9" />

<details><summary>Developer: Inspect Editor Tokens</summary>
<img width="585" height="434" alt="after-adding-to-grammer" src="https://github.com/user-attachments/assets/b810af98-04df-485b-8553-4b022bb774f8" />
</details> 
